### PR TITLE
Change Github social link

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,7 +23,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/vuejs/vitepress' },
+      { icon: 'github', link: 'https://github.com/renatomoor/unocss-preset-fluid' },
     ],
   },
   base: '/unocss-preset-fluid/',


### PR DESCRIPTION
The GitHub social link was directing to the GitHub of VitePress.

When I clicked it, I wanted to access your repository.

Thank you for the plugin!