### PR TITLE
Change extend options type to nullable

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -8,7 +8,7 @@ export interface PresetFluidOptions {
     /**
      * Min width in pixels where the fluid layout starts keeping the proportions of the minWidth.
      */
-    extendMinWidth?: number;
+    extendMinWidth?: number | null;
     /**
      * Max width in pixels where the fluid layout ends.
      * @default 1440
@@ -17,7 +17,7 @@ export interface PresetFluidOptions {
     /**
      * Max width in pixels where the fluid layout ends keeping the proportions of the maxWidth.
      */
-    extendMaxWidth?: number;
+    extendMaxWidth?: number | null;
     /**
      * Base font size in pixels.
      * @default 16

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export interface PresetFluidOptions {
   /**
    * Min width in pixels where the fluid layout starts keeping the proportions of the minWidth.
    */
-  extendMinWidth?: number
+  extendMinWidth?: number | null
   /**
    * Max width in pixels where the fluid layout ends.
    * @default 1440
@@ -19,7 +19,7 @@ export interface PresetFluidOptions {
   /**
    * Max width in pixels where the fluid layout ends keeping the proportions of the maxWidth.
    */
-  extendMaxWidth?: number
+  extendMaxWidth?: number | null
   /**
    * Base font size in pixels.
    * @default 16


### PR DESCRIPTION
I got the following type error when using null on `extendMaxWidth` and `extendMinWidth` configuration options (on examples in the doc it is using `null`):

![image](https://github.com/renatomoor/unocss-preset-fluid/assets/74366173/26af48be-8780-4acb-8231-5fdb8166f3ca)

I've changed types to allow null as values.