### PR TITLE
Add Fluid Ranges Option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,7 @@ Example:
     extendMinWidth: null,
     remBase: 16,
     useRemByDefault: false,
+    fluidRanges: null,
 }
 ```
 
@@ -68,6 +69,20 @@ For example
 <div class="f-w-16-32">...</div> <!-- Default from 16px to 32px -->
 <div class="f-w-1-2">...</div> <!-- RemByDefault from 1rem to 2rem -->
 ```
+
+#### FluidRanges
+This option allows you to define recurring spacings using predefined names.
+For example. With this fluid ranges:
+```js
+{
+  xs: [12, 16],
+  sm: [14, 18],
+  md: [18, 24],
+  lg: [22, 30],
+}
+```
+You will be able to use it as aliases. Therefore, `f-w-xs` will become `f-w-12-16`.
+
 
 ## Utilities
 

--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,17 +1,17 @@
 {
-  "hash": "f9de2d58",
-  "browserHash": "36059508",
+  "hash": "c2ebe762",
+  "browserHash": "fc3f5088",
   "optimized": {
     "vue": {
       "src": "../../../../node_modules/.pnpm/vue@3.3.8_typescript@5.2.2/node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "d9ec80d9",
+      "fileHash": "fe06ccc1",
       "needsInterop": false
     },
     "vitepress > @vue/devtools-api": {
       "src": "../../../../node_modules/.pnpm/@vue+devtools-api@6.5.1/node_modules/@vue/devtools-api/lib/esm/index.js",
       "file": "vitepress___@vue_devtools-api.js",
-      "fileHash": "e41ca7de",
+      "fileHash": "3c84ea6c",
       "needsInterop": false
     }
   },

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,4 +1,6 @@
 import type { Preset } from 'unocss';
+import { FluidRanges } from './main';
+
 export interface PresetFluidOptions {
     /**
      * Min width in pixels where the fluid layout starts.
@@ -28,5 +30,10 @@ export interface PresetFluidOptions {
      * @default false
      */
     useRemByDefault?: boolean;
+    /**
+     * A preset with predefined ranges of fluid spacing
+     * @default undefined;
+     */
+    fluidRanges?: FluidRanges | null
 }
 export declare function presetFluid(options?: PresetFluidOptions): Preset;


### PR DESCRIPTION
This feature allows the developer to define recurring used ranges.

For example:
Developers can use `f-w-sm` instead of `f-w-12-50`, by defining the `fluidRanges` options inside the plugin options.

QUESTION: 
- Should the files inside `/.vitepress/cache` be gitignored?